### PR TITLE
LOG-2348: Canoe: use appropriate docker images based on branch

### DIFF
--- a/cli/pipeline/pipeline_definition.go
+++ b/cli/pipeline/pipeline_definition.go
@@ -4,6 +4,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"log"
 	"regexp"
+	"strings"
 )
 
 type PipelineDefinitionStep struct {
@@ -48,4 +49,15 @@ func parsePipeline(data []byte) *PipelineDefinition {
 	}
 
 	return &pipeline
+}
+
+func (p *PipelineDefinitionStep) OverrideTag(tag string) {
+	if tag != "" {
+		currentParts := strings.Split(p.Image, ":")
+		parts := []string{
+			currentParts[0],
+			tag,
+		}
+		p.Image = strings.Join(parts, ":")
+	}
 }

--- a/cli/pipeline/pipeline_definition_test.go
+++ b/cli/pipeline/pipeline_definition_test.go
@@ -20,3 +20,23 @@ func TestParsePipeline(t *testing.T) {
 		t.Errorf("Expected bucket to be canoe-sample-pipeline, got %s", pipeline.Bucket)
 	}
 }
+
+func TestOverrideTag(t *testing.T) {
+	data, err := ioutil.ReadFile("test/sample_steps_passing.yml")
+	if err != nil {
+		panic(err.Error())
+	}
+	pipeline := parsePipeline(data)
+
+	pipeline.Steps[0].OverrideTag("")
+
+	if pipeline.Steps[0].Image != "219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:latest" {
+		t.Errorf("Image is %s", pipeline.Steps[0].Image)
+	}
+
+	pipeline.Steps[0].OverrideTag("foo")
+
+	if pipeline.Steps[0].Image != "219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:foo" {
+		t.Errorf("Image is %s", pipeline.Steps[0].Image)
+	}
+}

--- a/cli/pipeline/run.go
+++ b/cli/pipeline/run.go
@@ -32,6 +32,7 @@ import (
 type runCmdFlagsStruct struct {
 	StepName           string
 	BucketName         string
+	ImageTag           string
 	TailLogs           bool
 	Secrets            []string
 	Env                []string
@@ -67,6 +68,7 @@ func init() {
 	runCmdFlags = &runCmdFlagsStruct{}
 	runCmd.Flags().StringVarP(&runCmdFlags.StepName, "step", "s", "", "Single step to execute")
 	runCmd.Flags().StringVarP(&runCmdFlags.BucketName, "bucket", "b", "", "Bucket name")
+	runCmd.Flags().StringVarP(&runCmdFlags.ImageTag, "tag", "t", "", "Image tag (overrides the one defined in the pipeline)")
 	runCmd.Flags().BoolVarP(&runCmdFlags.TailLogs, "logs", "l", true, "Tail logs")
 	runCmd.Flags().StringSliceVarP(&runCmdFlags.Secrets, "secret", "S", []string{}, "Secret to pull into the environment (in the form ENV_VAR:secret_store:key_name)")
 	runCmd.Flags().StringSliceVarP(&runCmdFlags.Env, "env", "e", []string{}, "Environment variables to set (in the form name:value)")
@@ -96,6 +98,9 @@ func runPipeline(path string, flags *runCmdFlagsStruct) {
 	for _, step := range pipeline.Steps {
 		if flags.StepName != "" && step.Step != flags.StepName {
 			continue
+		}
+		if flags.ImageTag != "" {
+			step.OverrideTag(flags.ImageTag)
 		}
 		err = runPipelineStep(pipeline, &step, flags)
 		if err != nil {


### PR DESCRIPTION
Allow overriding the image tag from the command line

===

Jira story [#LOG-2348](https://deliveroo.atlassian.net/browse/LOG-2348) in project *Logistics*:

> Currently, the branch to use for docker images is specified in the pipeline yaml explicitly (as a tag). This is a bit error-prone, since it requires to change the tag when working on a branch, and remembering to set it back to "latest" before merging to master.
> 
> We should figure out a way to set the tag dynamically based on the branch being executed (possibly with a paddle command line switch; and propagating the branch name to Jenkins somehow).