### PR TITLE
LOG-2457: Paddle: log Pod status after termination

### DIFF
--- a/cli/pipeline/run.go
+++ b/cli/pipeline/run.go
@@ -219,9 +219,7 @@ func deleteAndWait(c kubernetes.Interface, podDefinition *PodDefinition, flags *
 				return true, err
 			}
 		}
-		if deleting {
-			log.Print("[paddle] .")
-		} else {
+		if !deleting {
 			log.Printf("[paddle] deleting pod %s", podDefinition.PodName)
 			deleting = true
 		}

--- a/cli/pipeline/run.go
+++ b/cli/pipeline/run.go
@@ -186,7 +186,7 @@ func runPipelineStep(pipeline *PipelineDefinition, step *PipelineDefinitionStep,
 			}
 		case <-ctx.Done():
 			pod, _ := pods.Get(podDefinition.PodName, metav1.GetOptions{})
-			reason := "Timeout waiting for pod to start. Cluster might not have sufficient resources."
+			reason := "Timed out waiting for pod to start. Cluster might not have sufficient resources."
 			if pod != nil {
 				for _, container := range pod.Status.ContainerStatuses {
 					if container.State.Waiting != nil {

--- a/cli/pipeline/run.go
+++ b/cli/pipeline/run.go
@@ -185,8 +185,17 @@ func runPipelineStep(pipeline *PipelineDefinition, step *PipelineDefinitionStep,
 				return errors.New(msg)
 			}
 		case <-ctx.Done():
+			pod, _ := pods.Get(podDefinition.PodName, metav1.GetOptions{})
+			reason := "Timeout waiting for pod to start. Cluster might not have sufficient resources."
+			if pod != nil {
+				for _, container := range pod.Status.ContainerStatuses {
+					if container.State.Waiting != nil {
+						reason = container.State.Waiting.Message
+					}
+				}
+			}
 			pods.Delete(podDefinition.PodName, &metav1.DeleteOptions{})
-			return errors.New("Timeout waiting for pod to start. Cluster might not have sufficient resources.")
+			return errors.New(reason)
 		}
 	}
 


### PR DESCRIPTION
Show termination reason; and pod status when starting times out (will show if pulling the image failed).

===

Jira story [#LOG-2457](https://deliveroo.atlassian.net/browse/LOG-2457) in project *Logistics*:

> When a Pod dies because it's OOM, we only see "killed" in the logs. Query the Pod status and show it in the logs.