### PR TITLE
Be more robust to goreleaser not being installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ go test ./...
 
 ## Release
 
-In order to release a new version, set up github export GITHUB_TOKEN=[YOUR_TOKEN]
+In order to release a new version, set up github export GITHUB_TOKEN=[YOUR_TOKEN]. Make sure that you have goreleaser installed from [goreleaser.com](http://goreleaser.com).
 
 Ensure your git repo is clean. Then update VERSION (no need to commit it, it will be committed automatically), and run:
 

--- a/release.sh
+++ b/release.sh
@@ -5,6 +5,7 @@ set -x
 
 die() { echo "$*" 1>&2 ; exit 1; }
 
+which goreleaser || die "Install goreleaser from http://goreleaser.com"
 VERSION=`cat VERSION | tr -d '\n'`
 git diff-index --quiet --cached HEAD -- || die "Index dirty, commit first"
 go generate ./cli


### PR DESCRIPTION
Otherwise release.sh fails after doing all the github stuff.