### PR TITLE
[RP-1048] Make sure version & branch are overridden in inputs.

### DIFF
--- a/cli/pipeline/pipeline_definition.go
+++ b/cli/pipeline/pipeline_definition.go
@@ -65,11 +65,19 @@ func (p *PipelineDefinitionStep) OverrideTag(tag string) {
 func (p *PipelineDefinitionStep) OverrideVersion(version string) {
 	if version != "" {
 		p.Version = version
+
+		for i := range p.Inputs {
+			p.Inputs[i].Version = version
+		}
 	}
 }
 
 func (p *PipelineDefinitionStep) OverrideBranch(branch string) {
 	if branch != "" {
 		p.Branch = branch
+
+		for i := range p.Inputs {
+			p.Inputs[i].Branch = branch
+		}
 	}
 }

--- a/cli/pipeline/pipeline_definition.go
+++ b/cli/pipeline/pipeline_definition.go
@@ -62,22 +62,26 @@ func (p *PipelineDefinitionStep) OverrideTag(tag string) {
 	}
 }
 
-func (p *PipelineDefinitionStep) OverrideVersion(version string) {
+func (p *PipelineDefinitionStep) OverrideVersion(version string, overrideInputs bool) {
 	if version != "" {
 		p.Version = version
 
-		for i := range p.Inputs {
-			p.Inputs[i].Version = version
+		if overrideInputs {
+			for i := range p.Inputs {
+				p.Inputs[i].Version = version
+			}
 		}
 	}
 }
 
-func (p *PipelineDefinitionStep) OverrideBranch(branch string) {
+func (p *PipelineDefinitionStep) OverrideBranch(branch string, overrideInputs bool) {
 	if branch != "" {
 		p.Branch = branch
 
-		for i := range p.Inputs {
-			p.Inputs[i].Branch = branch
+		if overrideInputs {
+			for i := range p.Inputs {
+				p.Inputs[i].Branch = branch
+			}
 		}
 	}
 }

--- a/cli/pipeline/pipeline_definition_test.go
+++ b/cli/pipeline/pipeline_definition_test.go
@@ -54,10 +54,14 @@ func TestOverrideVersion(t *testing.T) {
 		t.Errorf("Version is %s", pipeline.Steps[0].Version)
 	}
 
-	pipeline.Steps[0].OverrideVersion("foo")
+	pipeline.Steps[1].OverrideVersion("foo")
 
-	if pipeline.Steps[0].Version != "foo" {
-		t.Errorf("Version is %s", pipeline.Steps[0].Version)
+	if pipeline.Steps[1].Version != "foo" {
+		t.Errorf("Version is %s", pipeline.Steps[1].Version)
+	}
+
+	if pipeline.Steps[1].Inputs[0].Version != "foo" {
+		t.Errorf("Dependent input Version is %s", pipeline.Steps[1].Inputs[0].Version)
 	}
 }
 
@@ -74,9 +78,13 @@ func TestOverrideBranch(t *testing.T) {
 		t.Errorf("Branch is %s", pipeline.Steps[0].Branch)
 	}
 
-	pipeline.Steps[0].OverrideBranch("foo")
+	pipeline.Steps[1].OverrideBranch("foo")
 
-	if pipeline.Steps[0].Branch != "foo" {
-		t.Errorf("Branch is %s", pipeline.Steps[0].Branch)
+	if pipeline.Steps[1].Branch != "foo" {
+		t.Errorf("Branch is %s", pipeline.Steps[1].Branch)
+	}
+
+	if pipeline.Steps[1].Inputs[0].Branch != "foo" {
+		t.Errorf("Dependent input Branch is %s", pipeline.Steps[1].Inputs[0].Branch)
 	}
 }

--- a/cli/pipeline/pipeline_definition_test.go
+++ b/cli/pipeline/pipeline_definition_test.go
@@ -48,13 +48,13 @@ func TestOverrideVersion(t *testing.T) {
 	}
 	pipeline := parsePipeline(data)
 
-	pipeline.Steps[0].OverrideVersion("")
+	pipeline.Steps[0].OverrideVersion("", true)
 
 	if pipeline.Steps[0].Version != "version1" {
 		t.Errorf("Version is %s", pipeline.Steps[0].Version)
 	}
 
-	pipeline.Steps[1].OverrideVersion("foo")
+	pipeline.Steps[1].OverrideVersion("foo", true)
 
 	if pipeline.Steps[1].Version != "foo" {
 		t.Errorf("Version is %s", pipeline.Steps[1].Version)
@@ -72,13 +72,13 @@ func TestOverrideBranch(t *testing.T) {
 	}
 	pipeline := parsePipeline(data)
 
-	pipeline.Steps[0].OverrideBranch("")
+	pipeline.Steps[0].OverrideBranch("", true)
 
 	if pipeline.Steps[0].Branch != "master" {
 		t.Errorf("Branch is %s", pipeline.Steps[0].Branch)
 	}
 
-	pipeline.Steps[1].OverrideBranch("foo")
+	pipeline.Steps[1].OverrideBranch("foo", true)
 
 	if pipeline.Steps[1].Branch != "foo" {
 		t.Errorf("Branch is %s", pipeline.Steps[1].Branch)

--- a/cli/pipeline/run.go
+++ b/cli/pipeline/run.go
@@ -75,7 +75,7 @@ func init() {
 	runCmd.Flags().StringVarP(&runCmdFlags.StepBranch, "step-branch", "B", "", "Step branch (overrides the one defined in the pipeline)")
 	runCmd.Flags().StringVarP(&runCmdFlags.StepVersion, "step-version", "V", "", "Step version (overrides the one defined in the pipeline)")
 	runCmd.Flags().BoolVarP(&runCmdFlags.TailLogs, "logs", "l", true, "Tail logs")
-	runCmd.Flags().BoolVarP(&runCmdFlags.TailLogs, "override-inputs", "I", false, "Override input version/branch (only makes sense to use with -B or -V)")
+	runCmd.Flags().BoolVarP(&runCmdFlags.OverrideInputs, "override-inputs", "I", false, "Override input version/branch (only makes sense to use with -B or -V)")
 	runCmd.Flags().StringSliceVarP(&runCmdFlags.Secrets, "secret", "S", []string{}, "Secret to pull into the environment (in the form ENV_VAR:secret_store:key_name)")
 	runCmd.Flags().StringSliceVarP(&runCmdFlags.Env, "env", "e", []string{}, "Environment variables to set (in the form name:value)")
 	runCmdFlags.DeletePollInterval = defaultDeletePollInterval

--- a/cli/pipeline/run.go
+++ b/cli/pipeline/run.go
@@ -35,6 +35,7 @@ type runCmdFlagsStruct struct {
 	ImageTag           string
 	StepBranch         string
 	StepVersion        string
+	OverrideInputs     bool
 	TailLogs           bool
 	Secrets            []string
 	Env                []string
@@ -74,6 +75,7 @@ func init() {
 	runCmd.Flags().StringVarP(&runCmdFlags.StepBranch, "step-branch", "B", "", "Step branch (overrides the one defined in the pipeline)")
 	runCmd.Flags().StringVarP(&runCmdFlags.StepVersion, "step-version", "V", "", "Step version (overrides the one defined in the pipeline)")
 	runCmd.Flags().BoolVarP(&runCmdFlags.TailLogs, "logs", "l", true, "Tail logs")
+	runCmd.Flags().BoolVarP(&runCmdFlags.TailLogs, "override-inputs", "I", false, "Override input version/branch (only makes sense to use with -B or -V)")
 	runCmd.Flags().StringSliceVarP(&runCmdFlags.Secrets, "secret", "S", []string{}, "Secret to pull into the environment (in the form ENV_VAR:secret_store:key_name)")
 	runCmd.Flags().StringSliceVarP(&runCmdFlags.Env, "env", "e", []string{}, "Environment variables to set (in the form name:value)")
 	runCmdFlags.DeletePollInterval = defaultDeletePollInterval
@@ -107,10 +109,10 @@ func runPipeline(path string, flags *runCmdFlagsStruct) {
 			step.OverrideTag(flags.ImageTag)
 		}
 		if flags.StepBranch != "" {
-			step.OverrideBranch(flags.StepBranch)
+			step.OverrideBranch(flags.StepBranch, flags.OverrideInputs)
 		}
 		if flags.StepVersion != "" {
-			step.OverrideVersion(flags.StepVersion)
+			step.OverrideVersion(flags.StepVersion, flags.OverrideInputs)
 		}
 		err = runPipelineStep(pipeline, &step, flags)
 		if err != nil {


### PR DESCRIPTION
I missed the fact that these will also need to be overwritten in the Input definitions in almost all cases. (In the case where you need some complex multi-branch or multi-version dependencies, you'll have to fallback to specifying in pipeline-steps.yml)