### PR TITLE
Print the key that paddle fails to fetch

### DIFF
--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -163,7 +163,7 @@ func getObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutpu
 		} else {
 			retries--
 			if retries > 0 {
-				fmt.Printf("Error fetching from S3: %s; will retry in %v...	\n", err.Error(), s3RetriesSleep)
+				fmt.Printf("Error fetching from S3: %s, (%s); will retry in %v...	\n", *key, err.Error(), s3RetriesSleep)
 				time.Sleep(s3RetriesSleep)
 			}
 		}


### PR DESCRIPTION
This adds the key that paddle fails to fetch. Errors currently look like below, which make it slightly harder to understand exactly why it is failing:

```
2018/05/20 19:38:15 [rider-planning-postprocess-master/paddle]: 	status code: 404, request id: 1B852096F667FC73, host id: c2vrXdAJ7pKfHfGAQBQbpbM1z5hhsQv9Ra+QZjGjzpVKLFBxi5zFHDc/B4yibN5I2ew9qLS4vsM=; will retry in 10s...	
```