### PR TITLE
PRIC-846: Add docker socket as volume mount

### DIFF
--- a/cli/pipeline/template.go
+++ b/cli/pipeline/template.go
@@ -58,6 +58,10 @@ spec:
       emptyDir:
         medium: ''
       {{ end }}
+    -
+      name: docker-sock
+      hostPath:
+        path: /var/run/docker.sock
   containers:
     -
       name: main
@@ -67,6 +71,9 @@ spec:
         -
           name: shared-data
           mountPath: /data
+        -
+          name: docker-sock
+          mountPath: /var/run/docker.sock
       resources:
         limits:
           cpu: "{{ .Step.Resources.CPU }}"


### PR DESCRIPTION
## Why
We want to be able to build docker images inside Canoe steps, in order to enable us to package/deploy trained models as docker containers.

## What
The easiest way to build docker inside docker, is to actually connect to the host docker daemon via its own unix socket using a docker client library. In order to communicate via the unix socket though, we need to add a volume mount to the main container started by paddle steps.

I don't think it's necessary to make this an optional flag, since the volume mount should be harmless in cases where its unused, and in cases where you _do_ want to use it, it should be readily available without extra effort from the developer. Happy to hear opinions otherwise though.

## Questions
How do I specify the new paddle version, and deploy it? Is it automatic when I merge to master?