### PR TITLE
Use branch name from flag if supplied

### DIFF
--- a/cli/pipeline/template.go
+++ b/cli/pipeline/template.go
@@ -131,7 +131,7 @@ spec:
         - "-c"
         - "mkdir -p $INPUT_PATH $OUTPUT_PATH &&
           {{ range $index, $input := .Step.Inputs }}
-          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} &&
+          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ .BranchName }} -p {{ $input.Path }} &&
           {{ end }}
           touch /data/first-step.txt &&
           echo first step finished &&


### PR DESCRIPTION
The `data` command allows overriding the "branch" name in the S3 path, but is only applying it for `put`s, not for `get`s: this fixes that.