### PR TITLE
Allow overriding S3 bucket via command line

### DIFF
--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -34,6 +34,7 @@ import (
 var (
 	getBranch     string
 	getCommitPath string
+	getBucket     string
 )
 
 const (
@@ -50,15 +51,15 @@ var getCmd = &cobra.Command{
 
 Example:
 
-$ paddle data get -b experimental trained-model/version1 dest/path
+$ paddle data get -b experimental --bucket roo-pipeline trained-model/version1 dest/path
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		if !viper.IsSet("bucket") {
+		if getBucket == "" {
 			exitErrorf("Bucket not defined. Please define 'bucket' in your config file.")
 		}
 
 		source := S3Path{
-			bucket: viper.GetString("bucket"),
+			bucket: getBucket,
 			path:   fmt.Sprintf("%s/%s/%s", args[0], getBranch, getCommitPath),
 		}
 
@@ -68,6 +69,7 @@ $ paddle data get -b experimental trained-model/version1 dest/path
 
 func init() {
 	getCmd.Flags().StringVarP(&getBranch, "branch", "b", "master", "Branch to work on")
+	getCmd.Flags().StringVar(&getBucket, "bucket", viper.GetString("bucket"), "Branch to work on")
 	getCmd.Flags().StringVarP(&getCommitPath, "path", "p", "HEAD", "Path to fetch (instead of HEAD)")
 }
 

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -69,7 +69,7 @@ $ paddle data get -b experimental --bucket roo-pipeline trained-model/version1 d
 
 func init() {
 	getCmd.Flags().StringVarP(&getBranch, "branch", "b", "master", "Branch to work on")
-	getCmd.Flags().StringVar(&getBucket, "bucket", viper.GetString("bucket"), "Branch to work on")
+	getCmd.Flags().StringVar(&getBucket, "bucket", viper.GetString("bucket"), "Bucket to use")
 	getCmd.Flags().StringVarP(&getCommitPath, "path", "p", "HEAD", "Path to fetch (instead of HEAD)")
 }
 

--- a/cli/pipeline/pipeline_definition.go
+++ b/cli/pipeline/pipeline_definition.go
@@ -18,6 +18,7 @@ type PipelineDefinitionStep struct {
 		Version string `yaml:"version"`
 		Branch  string `yaml:"branch"`
 		Path    string `yaml:"path"`
+		Bucket  string `yaml:"bucket"`
 	} `yaml:"inputs"`
 	Commands  []string `yaml:"commands"`
 	Resources struct {

--- a/cli/pipeline/template.go
+++ b/cli/pipeline/template.go
@@ -131,7 +131,7 @@ spec:
         - "-c"
         - "mkdir -p $INPUT_PATH $OUTPUT_PATH &&
           {{ range $index, $input := .Step.Inputs }}
-          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} &&
+          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} {{ $input.Bucket | bucketParam }} &&
           {{ end }}
           touch /data/first-step.txt &&
           echo first step finished &&
@@ -206,6 +206,7 @@ func NewPodDefinition(pipelineDefinition *PipelineDefinition, pipelineDefinition
 func (p PodDefinition) compile() *bytes.Buffer {
 	fmap := template.FuncMap{
 		"sanitizeName": sanitizeName,
+		"bucketParam":  bucketParam,
 	}
 	tmpl := template.Must(template.New("podTemplate").Funcs(fmap).Parse(podTemplate))
 	buffer := new(bytes.Buffer)
@@ -254,4 +255,12 @@ func sanitizeName(name string) string {
 	str = strings.Replace(str, "_", "-", -1)
 	str = strings.Replace(str, "/", "-", -1)
 	return str
+}
+
+func bucketParam(bucket string) string {
+	if bucket == "" {
+		return "--bucket " + bucket
+	} else {
+		return ""
+	}
 }


### PR DESCRIPTION
## What

Allow overriding S3 bucket via command line

## Why

If you want to use the output from another pipeline (in another S3 bucket) as an input for your pipeline, you can use paddle and specify different S3 bucket.

[JIRA](https://deliveroo.atlassian.net/browse/LOG-3982)