### PR TITLE
PRIC-1356 Allow paddle to download individual files

### DIFF
--- a/cli/data/get_test.go
+++ b/cli/data/get_test.go
@@ -1,0 +1,36 @@
+package data
+
+import (
+    "github.com/aws/aws-sdk-go/service/s3"
+    "testing"
+)
+
+func TestFilterObjects(t *testing.T) {
+    var (
+        file1 = "file1.csv"
+        file2 = "file2.csv"
+        obj1  = &s3.Object{Key: &file1}
+        obj2  = &s3.Object{Key: &file2}
+        files = []string{"file1.csv"}
+    )
+
+    result := filterObjects([]*s3.Object{obj1, obj2}, files)
+
+    if len(result) != 1 {
+        t.Errorf("Failed to filter files, got: %v, want: %v.", len(result), len(files))
+    }
+}
+
+func TestFilterObjectsWithEmptyFiles(t *testing.T) {
+    var (
+        file = "file.csv"
+        obj  = &s3.Object{Key: &file}
+    )
+
+    result := filterObjects([]*s3.Object{obj}, []string{})
+
+    length := len(result)
+    if length != 1 {
+        t.Errorf("Failed to filter files, got: %v, want: %v.", length, length)
+    }
+}

--- a/cli/data/get_test.go
+++ b/cli/data/get_test.go
@@ -1,36 +1,36 @@
 package data
 
 import (
-    "github.com/aws/aws-sdk-go/service/s3"
-    "testing"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"testing"
 )
 
 func TestFilterObjects(t *testing.T) {
-    var (
-        file1 = "file1.csv"
-        file2 = "file2.csv"
-        obj1  = &s3.Object{Key: &file1}
-        obj2  = &s3.Object{Key: &file2}
-        files = []string{"file1.csv"}
-    )
+	var (
+		file1 = "file1.csv"
+		file2 = "file2.csv"
+		obj1  = &s3.Object{Key: &file1}
+		obj2  = &s3.Object{Key: &file2}
+		files = []string{"file1.csv"}
+	)
 
-    result := filterObjects([]*s3.Object{obj1, obj2}, files)
+	result := filterObjects([]*s3.Object{obj1, obj2}, files)
 
-    if len(result) != 1 {
-        t.Errorf("Failed to filter files, got: %v, want: %v.", len(result), len(files))
-    }
+	if len(result) != 1 {
+		t.Errorf("Failed to filter files, got: %v, want: %v.", len(result), len(files))
+	}
 }
 
 func TestFilterObjectsWithEmptyFiles(t *testing.T) {
-    var (
-        file = "file.csv"
-        obj  = &s3.Object{Key: &file}
-    )
+	var (
+		file = "file.csv"
+		obj  = &s3.Object{Key: &file}
+	)
 
-    result := filterObjects([]*s3.Object{obj}, []string{})
+	result := filterObjects([]*s3.Object{obj}, []string{})
 
-    length := len(result)
-    if length != 1 {
-        t.Errorf("Failed to filter files, got: %v, want: %v.", length, length)
-    }
+	length := len(result)
+	if length != 1 {
+		t.Errorf("Failed to filter files, got: %v, want: %v.", length, length)
+	}
 }


### PR DESCRIPTION
Jira ticket: https://deliveroo.atlassian.net/browse/PRIC-1356

> ### Allow paddle to download individual files
> 
> Currently when we use paddle to download files, you have to download the entire folder. Sometimes this can contain very large files that you don’t need. 
> 
> Add an option to only download specific files.