### PR TITLE
Delete the pod if the run is successful

### DIFF
--- a/cli/pipeline/run.go
+++ b/cli/pipeline/run.go
@@ -140,7 +140,6 @@ func runPipelineStep(pipeline *PipelineDefinition, step *PipelineDefinitionStep,
 
 	pods := clientset.CoreV1().Pods(pipeline.Namespace)
 
-
 	err = deleteAndWait(clientset, podDefinition, flags)
 	if err != nil {
 		return err
@@ -189,7 +188,7 @@ func runPipelineStep(pipeline *PipelineDefinition, step *PipelineDefinitionStep,
 				}
 			case Deleted:
 				log.Println("[paddle] Pod deleted")
-				return errors.New("Pod was deleted unexpectedly.")
+				return errors.New("pod was deleted unexpectedly")
 			case Removed:
 				if !removed[e.Container] {
 					log.Printf("[paddle] Container removed: %s", e.Container)
@@ -201,6 +200,7 @@ func runPipelineStep(pipeline *PipelineDefinition, step *PipelineDefinitionStep,
 				if podDefinition.needsVolume() {
 					deleteVolumeClaim(clientset, podDefinition, flags)
 				}
+				deleteAndWait(clientset, podDefinition, flags)
 				return nil
 			case Failed:
 				var msg string


### PR DESCRIPTION
## WHY

Currently in both production and staging the pods stay around after the job completes successfully. This creates allocation problems as the pods even if they are not running - they will still claim the resources on the machines. As such - even if no jobs are running our cluster stay utilized at a high percentage.

Additionally - this is creating scheduling problems - as don’t let the Kubernetes scheduler do try its best to minimize the resource utilization. Currently the Kubernetes scheduler does not have the concept of binpacking - but there is a PR open to address this: https://github.com/kubernetes/kubernetes/pull/77688

## WHAT

In paddle update this section: https://github.com/deliveroo/paddle/blob/master/cli/pipeline/run.go#L199-L204 to call the deleteAndWait function (that is called when the pod is first started): https://github.com/deliveroo/paddle/blob/master/cli/pipeline/run.go#L242.

Doing this will mean that we clean up the pods of successful jobs.