### PR TITLE
LOG-4178 Separate steps into subfolders

### DIFF
--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -36,6 +36,7 @@ var (
 	getCommitPath string
 	getBucket     string
 	getFiles      []string
+	getSubdir     string
 )
 
 const (
@@ -52,7 +53,7 @@ var getCmd = &cobra.Command{
 
 Example:
 
-$ paddle data get -b experimental --bucket roo-pipeline trained-model/version1 dest/path
+$ paddle data get -b experimental --bucket roo-pipeline --subdir extract trained-model/version1 dest/path
 $ paddle data get -b experimental --bucket roo-pipeline --files file1.csv,file2.csv trained-model/version1 dest/path
 `,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -68,7 +69,7 @@ $ paddle data get -b experimental --bucket roo-pipeline --files file1.csv,file2.
 			path:   fmt.Sprintf("%s/%s/%s", args[0], getBranch, getCommitPath),
 		}
 
-		copyPathToDestination(source, args[1], getFiles)
+		copyPathToDestination(source, args[1], getFiles, getSubdir)
 	},
 }
 
@@ -77,9 +78,10 @@ func init() {
 	getCmd.Flags().StringVar(&getBucket, "bucket", "", "Bucket to use")
 	getCmd.Flags().StringVarP(&getCommitPath, "path", "p", "HEAD", "Path to fetch (instead of HEAD)")
 	getCmd.Flags().StringSliceVarP(&getFiles, "files", "f", []string{}, "A list of files to download separated by comma")
+	getCmd.Flags().StringVar(&getSubdir, "subdir", "", "Subdirectory for destination path")
 }
 
-func copyPathToDestination(source S3Path, destination string, files []string) {
+func copyPathToDestination(source S3Path, destination string, files []string, subdir string) {
 	session := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
@@ -93,6 +95,9 @@ func copyPathToDestination(source S3Path, destination string, files []string) {
 	}
 	if !strings.HasSuffix(source.path, "/") {
 		source.path += "/"
+	}
+	if subdir != "" {
+		destination = parseDestination(destination, subdir)
 	}
 
 	fmt.Println("Copying " + source.path + " to " + destination)
@@ -111,6 +116,15 @@ func readHEAD(session *session.Session, source S3Path) string {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(out.Body)
 	return buf.String()
+}
+
+func parseDestination(destination string, subdir string) string {
+	if !strings.HasPrefix(destination, "/") {
+		destination += "/" + subdir
+	} else {
+		destination += subdir
+	}
+	return destination
 }
 
 func copy(session *session.Session, source S3Path, destination string, files []string) {

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -119,7 +119,7 @@ func readHEAD(session *session.Session, source S3Path) string {
 }
 
 func parseDestination(destination string, subdir string) string {
-	if !strings.HasPrefix(destination, "/") {
+	if !strings.HasSuffix(destination, "/") {
 		destination += "/" + subdir
 	} else {
 		destination += subdir

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -78,7 +78,7 @@ func init() {
 	getCmd.Flags().StringVar(&getBucket, "bucket", "", "Bucket to use")
 	getCmd.Flags().StringVarP(&getCommitPath, "path", "p", "HEAD", "Path to fetch (instead of HEAD)")
 	getCmd.Flags().StringSliceVarP(&getFiles, "files", "f", []string{}, "A list of files to download separated by comma")
-	getCmd.Flags().BoolVarP(&getSubdir, "subdir", "s", false, "Add step name as export path subdirectory")
+	getCmd.Flags().BoolVarP(&getSubdir, "subdir", "d", false, "Add step name as export path subdirectory")
 }
 
 func copyPathToDestination(source S3Path, destination string, files []string, subdir bool) {

--- a/cli/pipeline/pipeline_definition.go
+++ b/cli/pipeline/pipeline_definition.go
@@ -13,6 +13,7 @@ type PipelineDefinitionStep struct {
 	Version string `yaml:"version" json:"version"`
 	Branch  string `yaml:"branch" json:"branch"`
 	Image   string `yaml:"image" json:"image"`
+	Subdir  bool   `yaml:"subdir" json:"subdir"`
 	Inputs  []struct {
 		Step    string `yaml:"step" json:"step"`
 		Version string `yaml:"version" json:"version"`
@@ -62,6 +63,12 @@ func (p *PipelineDefinitionStep) OverrideTag(tag string) {
 			tag,
 		}
 		p.Image = strings.Join(parts, ":")
+	}
+}
+
+func (p *PipelineDefinitionStep) OverrideSubdir(subdir bool) {
+	if subdir {
+		p.Subdir = subdir
 	}
 }
 

--- a/cli/pipeline/pipeline_definition.go
+++ b/cli/pipeline/pipeline_definition.go
@@ -13,13 +13,13 @@ type PipelineDefinitionStep struct {
 	Version string `yaml:"version" json:"version"`
 	Branch  string `yaml:"branch" json:"branch"`
 	Image   string `yaml:"image" json:"image"`
-	Subdir  bool   `yaml:"subdir" json:"subdir"`
 	Inputs  []struct {
 		Step    string `yaml:"step" json:"step"`
 		Version string `yaml:"version" json:"version"`
 		Branch  string `yaml:"branch" json:"branch"`
 		Path    string `yaml:"path" json:"path"`
 		Bucket  string `yaml:"bucket" json:"bucket"`
+		Subdir  string `yaml:"subdir" json:"subdir"`
 	} `yaml:"inputs" json:"inputs"`
 	Commands  []string `yaml:"commands" json:"commands"`
 	Resources struct {
@@ -63,12 +63,6 @@ func (p *PipelineDefinitionStep) OverrideTag(tag string) {
 			tag,
 		}
 		p.Image = strings.Join(parts, ":")
-	}
-}
-
-func (p *PipelineDefinitionStep) OverrideSubdir(subdir bool) {
-	if subdir {
-		p.Subdir = subdir
 	}
 }
 

--- a/cli/pipeline/pipeline_definition_test.go
+++ b/cli/pipeline/pipeline_definition_test.go
@@ -10,10 +10,10 @@ func TestParsePipeline(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	if len(pipeline.Steps) != 2 {
-		t.Errorf("excepted two steps, got %d", len(pipeline.Steps))
+		t.Errorf("expected two steps, got %d", len(pipeline.Steps))
 	}
 
 	if pipeline.Bucket != "canoe-sample-pipeline" {
@@ -26,7 +26,7 @@ func TestOverrideTag(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	pipeline.Steps[0].OverrideTag("")
 
@@ -46,7 +46,7 @@ func TestOverrideVersion(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	pipeline.Steps[0].OverrideVersion("", true)
 
@@ -70,7 +70,7 @@ func TestOverrideBranch(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	pipeline.Steps[0].OverrideBranch("", true)
 

--- a/cli/pipeline/pipeline_definition_test.go
+++ b/cli/pipeline/pipeline_definition_test.go
@@ -19,6 +19,12 @@ func TestParsePipeline(t *testing.T) {
 	if pipeline.Bucket != "canoe-sample-pipeline" {
 		t.Errorf("Expected bucket to be canoe-sample-pipeline, got %s", pipeline.Bucket)
 	}
+
+	for _, step := range pipeline.Steps {
+		if step.Subdir != true {
+			t.Errorf("expected all steps 'subdir' to be true, got %t", step.Subdir)
+		}
+	}
 }
 
 func TestOverrideTag(t *testing.T) {

--- a/cli/pipeline/pipeline_definition_test.go
+++ b/cli/pipeline/pipeline_definition_test.go
@@ -20,10 +20,12 @@ func TestParsePipeline(t *testing.T) {
 		t.Errorf("Expected bucket to be canoe-sample-pipeline, got %s", pipeline.Bucket)
 	}
 
-	for _, step := range pipeline.Steps {
-		if step.Subdir != true {
-			t.Errorf("expected all steps 'subdir' to be true, got %t", step.Subdir)
-		}
+	if pipeline.Steps[0].Subdir != false {
+		t.Errorf("expected first step.subdir to be false but got %t", pipeline.Steps[0].Subdir)
+	}
+
+	if pipeline.Steps[1].Subdir != true {
+		t.Errorf("expected second step.subdir to be true but got %t", pipeline.Steps[1].Subdir)
 	}
 }
 
@@ -44,6 +46,26 @@ func TestOverrideTag(t *testing.T) {
 
 	if pipeline.Steps[0].Image != "219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:foo" {
 		t.Errorf("Image is %s", pipeline.Steps[0].Image)
+	}
+}
+
+func TestOverrideSubdir(t *testing.T) {
+	data, err := ioutil.ReadFile("test/sample_steps_passing.yml")
+	if err != nil {
+		panic(err.Error())
+	}
+	pipeline := ParsePipeline(data)
+
+	pipeline.Steps[0].OverrideSubdir(true)
+
+	if pipeline.Steps[0].Subdir != true {
+		t.Errorf("expected subdir to be overriden to true but it is still %t", pipeline.Steps[0].Subdir)
+	}
+
+	pipeline.Steps[1].OverrideSubdir(false)
+
+	if pipeline.Steps[1].Subdir != true {
+		t.Errorf("expected subdir not to be overriden from true but it is now %t", pipeline.Steps[1].Subdir)
 	}
 }
 

--- a/cli/pipeline/pipeline_definition_test.go
+++ b/cli/pipeline/pipeline_definition_test.go
@@ -20,12 +20,9 @@ func TestParsePipeline(t *testing.T) {
 		t.Errorf("Expected bucket to be canoe-sample-pipeline, got %s", pipeline.Bucket)
 	}
 
-	if pipeline.Steps[0].Subdir != false {
-		t.Errorf("expected first step.subdir to be false but got %t", pipeline.Steps[0].Subdir)
-	}
-
-	if pipeline.Steps[1].Subdir != true {
-		t.Errorf("expected second step.subdir to be true but got %t", pipeline.Steps[1].Subdir)
+	subdir := pipeline.Steps[1].Inputs[0].Subdir
+	if subdir != "step1-version1" {
+		t.Errorf("expected second step input subdir to be 'step1-version1' but got %s", subdir)
 	}
 }
 
@@ -46,26 +43,6 @@ func TestOverrideTag(t *testing.T) {
 
 	if pipeline.Steps[0].Image != "219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:foo" {
 		t.Errorf("Image is %s", pipeline.Steps[0].Image)
-	}
-}
-
-func TestOverrideSubdir(t *testing.T) {
-	data, err := ioutil.ReadFile("test/sample_steps_passing.yml")
-	if err != nil {
-		panic(err.Error())
-	}
-	pipeline := ParsePipeline(data)
-
-	pipeline.Steps[0].OverrideSubdir(true)
-
-	if pipeline.Steps[0].Subdir != true {
-		t.Errorf("expected subdir to be overriden to true but it is still %t", pipeline.Steps[0].Subdir)
-	}
-
-	pipeline.Steps[1].OverrideSubdir(false)
-
-	if pipeline.Steps[1].Subdir != true {
-		t.Errorf("expected subdir not to be overriden from true but it is now %t", pipeline.Steps[1].Subdir)
 	}
 }
 

--- a/cli/pipeline/run.go
+++ b/cli/pipeline/run.go
@@ -34,6 +34,7 @@ type runCmdFlagsStruct struct {
 	StepName           string
 	BucketName         string
 	ImageTag           string
+	Subdir             bool
 	StepBranch         string
 	StepVersion        string
 	OverrideInputs     bool
@@ -74,6 +75,7 @@ func init() {
 	runCmd.Flags().StringVarP(&runCmdFlags.StepName, "step", "s", "", "Single step to execute")
 	runCmd.Flags().StringVarP(&runCmdFlags.BucketName, "bucket", "b", "", "Bucket name")
 	runCmd.Flags().StringVarP(&runCmdFlags.ImageTag, "tag", "t", "", "Image tag (overrides the one defined in the pipeline)")
+	runCmd.Flags().BoolVarP(&runCmdFlags.Subdir, "subdir", "d", false, "Add step name as export path subdirectory")
 	runCmd.Flags().StringVarP(&runCmdFlags.StepBranch, "step-branch", "B", "", "Step branch (overrides the one defined in the pipeline)")
 	runCmd.Flags().StringVarP(&runCmdFlags.StepVersion, "step-version", "V", "", "Step version (overrides the one defined in the pipeline)")
 	runCmd.Flags().BoolVarP(&runCmdFlags.TailLogs, "logs", "l", true, "Tail logs")
@@ -110,6 +112,9 @@ func runPipeline(path string, flags *runCmdFlagsStruct) {
 		}
 		if flags.ImageTag != "" {
 			step.OverrideTag(flags.ImageTag)
+		}
+		if flags.Subdir {
+			step.OverrideSubdir(flags.Subdir)
 		}
 		if flags.StepBranch != "" {
 			step.OverrideBranch(flags.StepBranch, flags.OverrideInputs)

--- a/cli/pipeline/run.go
+++ b/cli/pipeline/run.go
@@ -34,7 +34,6 @@ type runCmdFlagsStruct struct {
 	StepName           string
 	BucketName         string
 	ImageTag           string
-	Subdir             bool
 	StepBranch         string
 	StepVersion        string
 	OverrideInputs     bool
@@ -75,7 +74,6 @@ func init() {
 	runCmd.Flags().StringVarP(&runCmdFlags.StepName, "step", "s", "", "Single step to execute")
 	runCmd.Flags().StringVarP(&runCmdFlags.BucketName, "bucket", "b", "", "Bucket name")
 	runCmd.Flags().StringVarP(&runCmdFlags.ImageTag, "tag", "t", "", "Image tag (overrides the one defined in the pipeline)")
-	runCmd.Flags().BoolVarP(&runCmdFlags.Subdir, "subdir", "d", false, "Add step name as export path subdirectory")
 	runCmd.Flags().StringVarP(&runCmdFlags.StepBranch, "step-branch", "B", "", "Step branch (overrides the one defined in the pipeline)")
 	runCmd.Flags().StringVarP(&runCmdFlags.StepVersion, "step-version", "V", "", "Step version (overrides the one defined in the pipeline)")
 	runCmd.Flags().BoolVarP(&runCmdFlags.TailLogs, "logs", "l", true, "Tail logs")
@@ -112,9 +110,6 @@ func runPipeline(path string, flags *runCmdFlagsStruct) {
 		}
 		if flags.ImageTag != "" {
 			step.OverrideTag(flags.ImageTag)
-		}
-		if flags.Subdir {
-			step.OverrideSubdir(flags.Subdir)
 		}
 		if flags.StepBranch != "" {
 			step.OverrideBranch(flags.StepBranch, flags.OverrideInputs)

--- a/cli/pipeline/run_test.go
+++ b/cli/pipeline/run_test.go
@@ -114,7 +114,7 @@ func TestRunPipelineSuccess(t *testing.T) {
 
 	for _, p := range expectPods {
 		if deleted[p] != 3 {
-			t.Errorf("expected delete of "+p+" to be called twice, got %i", deleted[p])
+			t.Errorf("expected delete of "+p+" to be called three times, got %i", deleted[p])
 		}
 		if created[p] != 1 {
 			t.Errorf("expected create of "+p+" to be called once, got %i", created[p])

--- a/cli/pipeline/run_test.go
+++ b/cli/pipeline/run_test.go
@@ -2,15 +2,16 @@ package pipeline
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
-	"testing"
-	"time"
 )
 
 func parseTimeOrDie(ts string) metav1.Time {
@@ -112,11 +113,11 @@ func TestRunPipelineSuccess(t *testing.T) {
 	expectPods := [2]string{"sample-steps-passing-version1-step1-master", "sample-steps-passing-version1a-step2-master"}
 
 	for _, p := range expectPods {
-		if deleted[p] != 2 {
-			t.Errorf("excepted delete of "+p+" to be called twice, got %i", deleted[p])
+		if deleted[p] != 3 {
+			t.Errorf("expected delete of "+p+" to be called twice, got %i", deleted[p])
 		}
 		if created[p] != 1 {
-			t.Errorf("excepted create of "+p+" to be called once, got %i", created[p])
+			t.Errorf("expected create of "+p+" to be called once, got %i", created[p])
 		}
 	}
 }
@@ -162,7 +163,7 @@ func TestRunPipelineFailure(t *testing.T) {
 	runPipeline("test/sample_steps_passing.yml", testRunFlags)
 
 	if len(errors) != 2 {
-		t.Errorf("excepted two errors, actual %v", len(errors))
+		t.Errorf("expected two errors, actual %v", len(errors))
 	}
 }
 
@@ -205,7 +206,7 @@ func TestRunPipelineStartTimeout(t *testing.T) {
 	runPipeline("test/sample_steps_passing.yml", &flags)
 
 	if len(errors) != 2 {
-		t.Errorf("excepted two errors, actual %v", len(errors))
+		t.Errorf("expected two errors, actual %v", len(errors))
 	}
 	msg := "[paddle] [Timed out waiting for pod to start. Cluster might not have sufficient resources.]"
 	for _, err := range errors {

--- a/cli/pipeline/template.go
+++ b/cli/pipeline/template.go
@@ -132,7 +132,7 @@ spec:
         - "-c"
         - "mkdir -p $INPUT_PATH $OUTPUT_PATH &&
           {{ range $index, $input := .Step.Inputs }}
-          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} {{ $input.Bucket | bucketParam }} &&
+          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} -d {{ .Step.Subdir }} {{ $input.Bucket | bucketParam }} &&
           {{ end }}
           touch /data/first-step.txt &&
           echo first step finished &&

--- a/cli/pipeline/template.go
+++ b/cli/pipeline/template.go
@@ -132,7 +132,7 @@ spec:
         - "-c"
         - "mkdir -p $INPUT_PATH $OUTPUT_PATH &&
           {{ range $index, $input := .Step.Inputs }}
-          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} -d {{ .Step.Subdir }} {{ $input.Bucket | bucketParam }} &&
+          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} -d {{ $input.Subdir }} {{ $input.Bucket | bucketParam }} &&
           {{ end }}
           touch /data/first-step.txt &&
           echo first step finished &&

--- a/cli/pipeline/template_test.go
+++ b/cli/pipeline/template_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -13,7 +13,7 @@ func TestCompileTemplate(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	podDefinition := NewPodDefinition(pipeline, &pipeline.Steps[0])
 
@@ -36,7 +36,7 @@ func TestSecrets(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	podDefinition := NewPodDefinition(pipeline, &pipeline.Steps[0])
 	secrets := []string{"ENV_VAR:secret_store:key_name"}
@@ -68,7 +68,7 @@ func TestEnv(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	podDefinition := NewPodDefinition(pipeline, &pipeline.Steps[0])
 	env := []string{"ENV_VAR:env_value"}

--- a/cli/pipeline/template_test.go
+++ b/cli/pipeline/template_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -15,19 +16,23 @@ func TestCompileTemplate(t *testing.T) {
 	}
 	pipeline := ParsePipeline(data)
 
-	podDefinition := NewPodDefinition(pipeline, &pipeline.Steps[0])
+	podDefinition := NewPodDefinition(pipeline, &pipeline.Steps[1])
 
 	stepPodBuffer := podDefinition.compile()
 
 	pod := &v1.Pod{}
 	yaml.NewYAMLOrJSONDecoder(stepPodBuffer, 4096).Decode(pod)
 
-	if pod.Name != "sample-steps-passing-version1-step1-master" {
+	if pod.Name != "sample-steps-passing-version1a-step2-master" {
 		t.Errorf("Pod name is %s", pod.Name)
 	}
 
 	if pod.Spec.Containers[0].Image != pipeline.Steps[0].Image {
 		t.Errorf("First image is %s", pod.Spec.Containers[0].Image)
+	}
+
+	if !strings.Contains(pod.Spec.Containers[1].Command[2], "-d step1-version1") {
+		t.Errorf("Expected paddle get command to contain -d step1-version1, but it did not")
 	}
 }
 

--- a/cli/pipeline/test/sample_steps_passing.yml
+++ b/cli/pipeline/test/sample_steps_passing.yml
@@ -10,6 +10,7 @@ steps:
     inputs: []
     image: 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:latest
     branch: master
+    subdir: true
     commands:
       - echo executing sample-pipeline-data > ${OUTPUT_PATH}/sample-pipeline-data.txt
     resources:
@@ -27,6 +28,7 @@ steps:
         path: HEAD
     image: 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:latest
     branch: master
+    subdir: true
     commands:
       - echo executing sample-pipeline-data > ${OUTPUT_PATH}/sample-pipeline-data-model.txt
     resources:

--- a/cli/pipeline/test/sample_steps_passing.yml
+++ b/cli/pipeline/test/sample_steps_passing.yml
@@ -10,7 +10,6 @@ steps:
     inputs: []
     image: 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:latest
     branch: master
-    subdir: false
     commands:
       - echo executing sample-pipeline-data > ${OUTPUT_PATH}/sample-pipeline-data.txt
     resources:
@@ -26,9 +25,9 @@ steps:
         version: version1
         branch: master
         path: HEAD
+        subdir: 'step1-version1'
     image: 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:latest
     branch: master
-    subdir: true
     commands:
       - echo executing sample-pipeline-data > ${OUTPUT_PATH}/sample-pipeline-data-model.txt
     resources:

--- a/cli/pipeline/test/sample_steps_passing.yml
+++ b/cli/pipeline/test/sample_steps_passing.yml
@@ -10,7 +10,7 @@ steps:
     inputs: []
     image: 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:latest
     branch: master
-    subdir: true
+    subdir: false
     commands:
       - echo executing sample-pipeline-data > ${OUTPUT_PATH}/sample-pipeline-data.txt
     resources:


### PR DESCRIPTION
Adds a new `subdir` attribute to the paddle config `yaml` files to enable S3 data from prior input steps to be imported into subdirectories corresponding to the corresponding step name.

e.g. instead of importing all files into `/data/input/`, files from each step will be imported into subdirectories `/data/input/{step_name}`

Also allows override of `subdir` attribute from `paddle pipeline run` command

Ticket: https://deliveroo.atlassian.net/browse/LOG-4178