### PR TITLE
LOG-4178 Separate steps into subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,66 @@ region=eu-west-1
 $ go build
 ```
 
-## Testing
+## Running Unit Tests
 
 ```
 $ go test ./...
 ```
 
+## Testing on Staging
+There is no dedicated test environment in staging for Paddle, but it is possible to test in staging using another Canoe pipeline that uses Paddle.
+
+1. Download and setup a pipeline repo that can be tested in staging, for example [`rider-planning-pipeline`](https://github.com/deliveroo/rider-planning-pipeline). Make sure you can build at least one of the pipeline steps listed in the definition `yml` file. The step should also contain inputs from a previous step if the paddle `get` command needs to be tested.
+2. Modify the paddle template.go `podTemplate` to use a temporary paddlecontainer tag. e.g `localtest001`. The `latest` tag cannot be used as it is pulled into production images.
+    ```
+    ...
+    image: "219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:localtest001"
+    ...
+    ```
+3. Copy the paddle build that needs to be tested to root of pipeline repo. Build using:
+    ```
+    go build
+    ```
+4. Copy a linux+amd64 paddle build that needs to be tested to the root of a new directory. Build for linux+amd64 using:
+    ```
+    GOOS=linux GOARCH=amd64 go build
+    ```
+5. Create a new Dockerfile in the same directory with the following content:
+    ```
+    FROM ubuntu
+
+    RUN apt-get update
+    RUN apt-get install -y ca-certificates curl wget
+
+    COPY ./paddle /usr/bin/paddle
+    ```
+6. From a shell, build and push a Docker image using the Dockerfile. Ensure local AWS credentials are setup to enable login.
+
+    **The image _must_ be built using a tag other than `latest` otherwise the image used in production will be overwritten!** In the example below, `localtest001` has been used to match the change made above.
+    ```
+    $(aws ecr get-login --profile k8s_production --no-include-email --region eu-west-1)
+
+    docker build -t 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:localtest001 .
+
+    docker push 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:localtest001
+    ```
+7. Modify the testing step(s) in the pipeline `yml` file with the test paddle container tag e.g. `localtest001` and make any other amendements as necessary.
+8. Re-run the pipeline to test the new version of paddle.
+9. If successful, follow the process below to release a new version of paddle.
+
 ## Release
 
 In order to release a new version, set up github export GITHUB_TOKEN=[YOUR_TOKEN]. Make sure that you have goreleaser installed from [goreleaser.com](http://goreleaser.com).
 
-Ensure your git repo is clean. Then update VERSION (no need to commit it, it will be committed automatically), and run:
+Ensure your git repo is clean, new PRs have already merged and your branch is set to master. Then update VERSION (no need to commit it, it will be committed automatically), and run:
 
 ```
 $ ./release.sh
+```
+
+If the final `goreleaser` part of this process fails (e.g. due to a missing GITHUB_TOKEN or `goreleaser` install), the version will have likely been incremented and pushed to origin already. In this case, run the final `goreleaser` step manually:
+```
+goreleaser --rm-dist
 ```
 
 ## Usage

--- a/cli/pipeline/pipeline_definition.go
+++ b/cli/pipeline/pipeline_definition.go
@@ -19,6 +19,7 @@ type PipelineDefinitionStep struct {
 		Branch  string `yaml:"branch" json:"branch"`
 		Path    string `yaml:"path" json:"path"`
 		Bucket  string `yaml:"bucket" json:"bucket"`
+		Subdir  string `yaml:"subdir" json:"subdir"`
 	} `yaml:"inputs" json:"inputs"`
 	Commands  []string `yaml:"commands" json:"commands"`
 	Resources struct {

--- a/cli/pipeline/pipeline_definition_test.go
+++ b/cli/pipeline/pipeline_definition_test.go
@@ -10,14 +10,19 @@ func TestParsePipeline(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	if len(pipeline.Steps) != 2 {
-		t.Errorf("excepted two steps, got %d", len(pipeline.Steps))
+		t.Errorf("expected two steps, got %d", len(pipeline.Steps))
 	}
 
 	if pipeline.Bucket != "canoe-sample-pipeline" {
 		t.Errorf("Expected bucket to be canoe-sample-pipeline, got %s", pipeline.Bucket)
+	}
+
+	subdir := pipeline.Steps[1].Inputs[0].Subdir
+	if subdir != "step1-version1" {
+		t.Errorf("expected second step input subdir to be 'step1-version1' but got %s", subdir)
 	}
 }
 
@@ -26,7 +31,7 @@ func TestOverrideTag(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	pipeline.Steps[0].OverrideTag("")
 
@@ -46,7 +51,7 @@ func TestOverrideVersion(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	pipeline.Steps[0].OverrideVersion("", true)
 
@@ -70,7 +75,7 @@ func TestOverrideBranch(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	pipeline.Steps[0].OverrideBranch("", true)
 

--- a/cli/pipeline/run_test.go
+++ b/cli/pipeline/run_test.go
@@ -2,15 +2,16 @@ package pipeline
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
-	"testing"
-	"time"
 )
 
 func parseTimeOrDie(ts string) metav1.Time {
@@ -112,11 +113,11 @@ func TestRunPipelineSuccess(t *testing.T) {
 	expectPods := [2]string{"sample-steps-passing-version1-step1-master", "sample-steps-passing-version1a-step2-master"}
 
 	for _, p := range expectPods {
-		if deleted[p] != 2 {
-			t.Errorf("excepted delete of "+p+" to be called twice, got %i", deleted[p])
+		if deleted[p] != 3 {
+			t.Errorf("expected delete of "+p+" to be called three times, got %i", deleted[p])
 		}
 		if created[p] != 1 {
-			t.Errorf("excepted create of "+p+" to be called once, got %i", created[p])
+			t.Errorf("expected create of "+p+" to be called once, got %i", created[p])
 		}
 	}
 }
@@ -162,7 +163,7 @@ func TestRunPipelineFailure(t *testing.T) {
 	runPipeline("test/sample_steps_passing.yml", testRunFlags)
 
 	if len(errors) != 2 {
-		t.Errorf("excepted two errors, actual %v", len(errors))
+		t.Errorf("expected two errors, actual %v", len(errors))
 	}
 }
 
@@ -205,7 +206,7 @@ func TestRunPipelineStartTimeout(t *testing.T) {
 	runPipeline("test/sample_steps_passing.yml", &flags)
 
 	if len(errors) != 2 {
-		t.Errorf("excepted two errors, actual %v", len(errors))
+		t.Errorf("expected two errors, actual %v", len(errors))
 	}
 	msg := "[paddle] [Timed out waiting for pod to start. Cluster might not have sufficient resources.]"
 	for _, err := range errors {

--- a/cli/pipeline/template.go
+++ b/cli/pipeline/template.go
@@ -132,7 +132,7 @@ spec:
         - "-c"
         - "mkdir -p $INPUT_PATH $OUTPUT_PATH &&
           {{ range $index, $input := .Step.Inputs }}
-          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} -d {{ $input.Subdir }} {{ $input.Bucket | bucketParam }} &&
+          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} {{ $input.Bucket | bucketParam }} {{ $input.Subdir | subdirParam }} &&
           {{ end }}
           touch /data/first-step.txt &&
           echo first step finished &&
@@ -209,6 +209,7 @@ func (p PodDefinition) compile() *bytes.Buffer {
 	fmap := template.FuncMap{
 		"sanitizeName": sanitizeName,
 		"bucketParam":  p.bucketParam,
+		"subdirParam":  p.subdirParam,
 	}
 	tmpl := template.Must(template.New("podTemplate").Funcs(fmap).Parse(podTemplate))
 	buffer := new(bytes.Buffer)
@@ -265,6 +266,13 @@ func (p *PodDefinition) bucketParam(bucket string) string {
 			bucket = bucketReplacement
 		}
 		return "--bucket " + bucket
+	}
+	return ""
+}
+
+func (p *PodDefinition) subdirParam(subdir string) string {
+	if subdir != "" {
+		return "-d " + subdir
 	}
 	return ""
 }

--- a/cli/pipeline/template.go
+++ b/cli/pipeline/template.go
@@ -132,7 +132,7 @@ spec:
         - "-c"
         - "mkdir -p $INPUT_PATH $OUTPUT_PATH &&
           {{ range $index, $input := .Step.Inputs }}
-          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} {{ $input.Bucket | bucketParam }} &&
+          paddle data get {{ $input.Step }}/{{ $input.Version }} $INPUT_PATH -b {{ $input.Branch | sanitizeName }} -p {{ $input.Path }} -d {{ $input.Subdir }} {{ $input.Bucket | bucketParam }} &&
           {{ end }}
           touch /data/first-step.txt &&
           echo first step finished &&

--- a/cli/pipeline/template_test.go
+++ b/cli/pipeline/template_test.go
@@ -2,9 +2,10 @@ package pipeline
 
 import (
 	"io/ioutil"
+	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -13,21 +14,25 @@ func TestCompileTemplate(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
-	podDefinition := NewPodDefinition(pipeline, &pipeline.Steps[0])
+	podDefinition := NewPodDefinition(pipeline, &pipeline.Steps[1])
 
 	stepPodBuffer := podDefinition.compile()
 
 	pod := &v1.Pod{}
 	yaml.NewYAMLOrJSONDecoder(stepPodBuffer, 4096).Decode(pod)
 
-	if pod.Name != "sample-steps-passing-version1-step1-master" {
+	if pod.Name != "sample-steps-passing-version1a-step2-master" {
 		t.Errorf("Pod name is %s", pod.Name)
 	}
 
 	if pod.Spec.Containers[0].Image != pipeline.Steps[0].Image {
 		t.Errorf("First image is %s", pod.Spec.Containers[0].Image)
+	}
+
+	if !strings.Contains(pod.Spec.Containers[1].Command[2], "-d step1-version1") {
+		t.Errorf("Expected paddle get command to contain -d step1-version1, but it did not")
 	}
 }
 
@@ -36,7 +41,7 @@ func TestSecrets(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	podDefinition := NewPodDefinition(pipeline, &pipeline.Steps[0])
 	secrets := []string{"ENV_VAR:secret_store:key_name"}
@@ -68,7 +73,7 @@ func TestEnv(t *testing.T) {
 	if err != nil {
 		panic(err.Error())
 	}
-	pipeline := parsePipeline(data)
+	pipeline := ParsePipeline(data)
 
 	podDefinition := NewPodDefinition(pipeline, &pipeline.Steps[0])
 	env := []string{"ENV_VAR:env_value"}

--- a/cli/pipeline/template_test.go
+++ b/cli/pipeline/template_test.go
@@ -34,6 +34,10 @@ func TestCompileTemplate(t *testing.T) {
 	if !strings.Contains(pod.Spec.Containers[1].Command[2], "-d step1-version1") {
 		t.Errorf("Expected paddle get command to contain -d step1-version1, but it did not")
 	}
+
+	if strings.Count(pod.Spec.Containers[1].Command[2], "-d") != 1 {
+		t.Errorf("Only one paddle get command should contain the -d parameter")
+	}
 }
 
 func TestSecrets(t *testing.T) {

--- a/cli/pipeline/test/sample_steps_passing.yml
+++ b/cli/pipeline/test/sample_steps_passing.yml
@@ -26,6 +26,11 @@ steps:
         branch: master
         path: HEAD
         subdir: 'step1-version1'
+      -
+        step: step1
+        version: version1
+        branch: master
+        path: HEAD
     image: 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:latest
     branch: master
     commands:

--- a/cli/pipeline/test/sample_steps_passing.yml
+++ b/cli/pipeline/test/sample_steps_passing.yml
@@ -25,6 +25,7 @@ steps:
         version: version1
         branch: master
         path: HEAD
+        subdir: 'step1-version1'
     image: 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:latest
     branch: master
     commands:


### PR DESCRIPTION
Reverts deliveroo/paddle#36 (which is itself a revert of the original PR which contained a bug)

Also fix the bug whereby a default `-d` parameter is required if `subdir` option is not specified in the YAML file.