### PR TITLE
Capture the command output logs

### DIFF
--- a/cli/pipeline/template.go
+++ b/cli/pipeline/template.go
@@ -84,7 +84,7 @@ spec:
         - "-c"
         - "while true; do if [ -e /data/first-step.txt ]; then ((
           {{ range $index, $command := .Step.Commands }}
-          ({{ $command }}) &&
+          ({{ $command }}) 2>&1 | tee /data/output/output-command-{{$index}}.log &&
           {{ end }}
           touch /data/main-passed.txt) || (touch /data/main-failed.txt && exit 1)) && touch /data/main.txt; break; fi; done"
       env:


### PR DESCRIPTION
This can prove useful in the future if we want to debug a particular run
but we no longer have the container around - it got deleted, or we no
longer have the Jenkins run.