### PR TITLE
Set `pipefail` to ensure correct exit code

### DIFF
--- a/cli/pipeline/template.go
+++ b/cli/pipeline/template.go
@@ -80,9 +80,10 @@ spec:
           cpu: "{{ .Step.Resources.CPU }}"
           memory: "{{ .Step.Resources.Memory }}"
       command:
-        - "/bin/sh"
+        - "/bin/bash"
         - "-c"
-        - "while true; do if [ -e /data/first-step.txt ]; then ((
+        - "set -o pipefail &&
+          while true; do if [ -e /data/first-step.txt ]; then ((
           {{ range $index, $command := .Step.Commands }}
           ({{ $command }}) 2>&1 | tee /data/output/output-command-{{$index}}.log &&
           {{ end }}


### PR DESCRIPTION
If we don't set `pipefail` the exit code will be that of the `tee`
command which will be successful even if the previous command (the one
doing the work) has failed.

As part of this I needed to use `/bin/bash` instead of `/bin/sh` but
since our base image is Ubuntu - this is not a problem.

Helpful SO: https://stackoverflow.com/questions/6871859/piping-command-output-to-tee-but-also-save-exit-code-of-command