### PR TITLE
Don't overwrite branches with custom buckets.

### DIFF
--- a/cli/pipeline/pipeline_definition.go
+++ b/cli/pipeline/pipeline_definition.go
@@ -14,13 +14,13 @@ type PipelineDefinitionStep struct {
 	Branch  string `yaml:"branch" json:"branch"`
 	Image   string `yaml:"image" json:"image"`
 	Inputs  []struct {
-		Step    string `yaml:"step" json:"step"`
-		Version string `yaml:"version" json:"version"`
-		Branch  string `yaml:"branch" json:"branch"`
-		Path    string `yaml:"path" json:"path"`
-		Bucket  string `yaml:"bucket" json:"bucket"`
+		Step    string   `yaml:"step" json:"step"`
+		Version string   `yaml:"version" json:"version"`
+		Branch  string   `yaml:"branch" json:"branch"`
+		Path    string   `yaml:"path" json:"path"`
+		Bucket  string   `yaml:"bucket" json:"bucket"`
 		Keys    []string `yaml:"keys" json:"keys"`
-		Subdir  string `yaml:"subdir" json:"subdir"`
+		Subdir  string   `yaml:"subdir" json:"subdir"`
 	} `yaml:"inputs" json:"inputs"`
 	Commands  []string `yaml:"commands" json:"commands"`
 	Resources struct {
@@ -85,7 +85,11 @@ func (p *PipelineDefinitionStep) OverrideBranch(branch string, overrideInputs bo
 
 		if overrideInputs {
 			for i := range p.Inputs {
-				p.Inputs[i].Branch = branch
+				// If a bucket is passed in don't overwrite the branch as it's reaching
+				// into another pipeline's output.
+				if p.Inputs[i].Bucket == "" {
+					p.Inputs[i].Branch = branch
+				}
 			}
 		}
 	}

--- a/cli/pipeline/pipeline_definition_test.go
+++ b/cli/pipeline/pipeline_definition_test.go
@@ -92,4 +92,8 @@ func TestOverrideBranch(t *testing.T) {
 	if pipeline.Steps[1].Inputs[0].Branch != "foo" {
 		t.Errorf("Dependent input Branch is %s", pipeline.Steps[1].Inputs[0].Branch)
 	}
+
+	if pipeline.Steps[1].Inputs[2].Branch == "foo" {
+		t.Errorf("Branch is %s, should be master", pipeline.Steps[1].Branch)
+	}
 }

--- a/cli/pipeline/test/sample_steps_passing.yml
+++ b/cli/pipeline/test/sample_steps_passing.yml
@@ -31,6 +31,12 @@ steps:
         version: version1
         branch: master
         path: HEAD
+      -
+        step: step2
+        version: version1
+        branch: master
+        path: HEAD
+        bucket: lord_buckethead
     image: 219541440308.dkr.ecr.eu-west-1.amazonaws.com/paddlecontainer:latest
     branch: master
     commands:


### PR DESCRIPTION
This commit only overwrites a branch if the input uses the default
bucket for the pipeline. If the bucket is set this means that you're
reaching out into the outputs of other pipelines which will not
necessarily have a branch with the same name on.

Those specifying custom buckets will also need to provide the correct
branch name.