### PR TITLE
Apply retries around the whole download operation

### DIFF
--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -243,12 +243,7 @@ func process(s3Client *s3.S3, src S3Path, basePath string, filePath string, sem 
 }
 
 func copyS3ObjectToFile(s3Client *s3.S3, src S3Path, filePath string, file *os.File) error {
-	err := getObject(s3Client, aws.String(src.bucket), &filePath, file)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return getObject(s3Client, aws.String(src.bucket), &filePath, file)
 }
 
 func getObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) error {
@@ -258,7 +253,7 @@ func getObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) erro
 
 	retries := s3Retries
 	for retries > 0 {
-		_, err := tryGetObject(s3Client, bucket, key, file)
+		err := tryGetObject(s3Client, bucket, key, file)
 		if err == nil {
 			return nil
 		}
@@ -272,19 +267,19 @@ func getObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) erro
 	return err
 }
 
-func tryGetObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) (*s3.GetObjectOutput, error) {
+func tryGetObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) error {
 	out, err := s3Client.GetObject(&s3.GetObjectInput{
 		Bucket: bucket,
 		Key:    key,
 	})
 
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	defer out.Body.Close()
 
-	return out, storeS3ObjectToFile(out, file)
+	return storeS3ObjectToFile(out, file)
 }
 
 func storeS3ObjectToFile(obj *s3.GetObjectOutput, file *os.File) error {

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -243,15 +243,11 @@ func process(s3Client *s3.S3, src S3Path, basePath string, filePath string, sem 
 }
 
 func copyS3ObjectToFile(s3Client *s3.S3, src S3Path, filePath string, file *os.File) error {
-	return getObject(s3Client, aws.String(src.bucket), &filePath, file)
-}
-
-func getObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) error {
 	var err error
 
 	retries := s3Retries
 	for retries > 0 {
-		err = tryGetObject(s3Client, bucket, key, file)
+		err = tryGetObject(s3Client, aws.String(src.bucket), &filePath, file)
 		if err == nil {
 			// we're done
 			return nil
@@ -260,7 +256,7 @@ func getObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) erro
 		resetFileForWriting(file)
 		retries--
 		if retries > 0 {
-			fmt.Printf("Error fetching from S3: %s, (%s); will retry in %v...	\n", *key, err.Error(), s3RetriesSleep)
+			fmt.Printf("Error fetching from S3: %s, (%s); will retry in %v...	\n", filePath, err.Error(), s3RetriesSleep)
 			time.Sleep(s3RetriesSleep)
 		}
 	}

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -262,15 +262,15 @@ func store(obj *s3.GetObjectOutput, destination string) error {
 
 	file, err := os.Create(destination)
 	if err != nil {
-		return errors.Wrapf(err, "creating destination %s", destination)
+		return errors.Wrapf(err, "creating destination %s", file.Name())
 	}
 	defer file.Close()
 
 	bytes, err := io.Copy(file, obj.Body)
 	if err != nil {
-		return errors.Wrapf(err, "copying file %s", destination)
+		return errors.Wrapf(err, "copying file %s", file.Name())
 	}
 
-	fmt.Printf("%s -> %d bytes\n", destination, bytes)
+	fmt.Printf("%s -> %d bytes\n", file.Name(), bytes)
 	return nil
 }

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -258,14 +258,9 @@ func getObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutpu
 }
 
 func store(obj *s3.GetObjectOutput, destination string) error {
-	err := os.MkdirAll(filepath.Dir(destination), 0777)
+	file, err := createFile(destination)
 	if err != nil {
-		return errors.Wrapf(err, "creating directory %s", filepath.Dir(destination))
-	}
-
-	file, err := os.Create(destination)
-	if err != nil {
-		return errors.Wrapf(err, "creating destination %s", file.Name())
+		return err
 	}
 	defer file.Close()
 
@@ -276,4 +271,17 @@ func store(obj *s3.GetObjectOutput, destination string) error {
 
 	fmt.Printf("%s -> %d bytes\n", file.Name(), bytes)
 	return nil
+}
+
+func createFile(destination string) (*os.File, error) {
+	err := os.MkdirAll(filepath.Dir(destination), 0777)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating directory %s", filepath.Dir(destination))
+	}
+
+	file, err := os.Create(destination)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating destination %s", file.Name())
+	}
+	return file, nil
 }

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -259,6 +259,9 @@ func getObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutpu
 
 func store(obj *s3.GetObjectOutput, destination string) error {
 	err := os.MkdirAll(filepath.Dir(destination), 0777)
+	if err != nil {
+		return errors.Wrapf(err, "creating directory %s", filepath.Dir(destination))
+	}
 
 	file, err := os.Create(destination)
 	if err != nil {

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -226,17 +226,22 @@ func process(s3Client *s3.S3, src S3Path, basePath string, filePath string, sem 
 	}
 
 	defer file.Close()
-	
+
+	err = copyS3ObjectToFile(s3Client, src, filePath, file)
+	if err != nil {
+		exitErrorf("%v", err)
+	}
+}
+
+func copyS3ObjectToFile(s3Client *s3.S3, src S3Path, filePath string, file *os.File) error {
 	out, err := getObject(s3Client, aws.String(src.bucket), &filePath)
 	if err != nil {
-		exitErrorf("%v", err)
+		return err
 	}
+
 	defer out.Body.Close()
 
-	err = storeS3ObjectToFile(out, file)
-	if err != nil {
-		exitErrorf("%v", err)
-	}
+	return storeS3ObjectToFile(out, file)
 }
 
 func getObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutput, error) {

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -123,7 +123,7 @@ func readHEAD(session *session.Session, source S3Path) string {
 
 	err = copyS3ObjectToFile(svc, source, source.path, tempFile)
 	if err != nil {
-		exitErrorf("Error reading HEAD: %v", err)
+		exitErrorf("Error copying HEAD: %v", err)
 	}
 
 	contents, err := ioutil.ReadFile(tempFile.Name())

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -247,14 +247,13 @@ func copyS3ObjectToFile(s3Client *s3.S3, src S3Path, filePath string, file *os.F
 }
 
 func getObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) error {
-	var (
-		err error
-	)
+	var err error
 
 	retries := s3Retries
 	for retries > 0 {
-		err := tryGetObject(s3Client, bucket, key, file)
+		err = tryGetObject(s3Client, bucket, key, file)
 		if err == nil {
+			// we're done
 			return nil
 		}
 

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -258,6 +258,7 @@ func getObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) erro
 			return nil
 		}
 
+		resetFileForWriting(file)
 		retries--
 		if retries > 0 {
 			fmt.Printf("Error fetching from S3: %s, (%s); will retry in %v...	\n", *key, err.Error(), s3RetriesSleep)
@@ -265,6 +266,11 @@ func getObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) erro
 		}
 	}
 	return err
+}
+
+func resetFileForWriting(file *os.File) {
+	file.Truncate(0)
+	file.Seek(0, 0)
 }
 
 func tryGetObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) error {

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -242,7 +242,11 @@ func process(s3Client *s3.S3, src S3Path, basePath string, filePath string, sem 
 	}
 }
 
-func copyS3ObjectToFile(s3Client *s3.S3, src S3Path, filePath string, file *os.File) error {
+type S3Getter interface {
+	GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)
+}
+
+func copyS3ObjectToFile(s3Client S3Getter, src S3Path, filePath string, file *os.File) error {
 	var err error
 
 	retries := s3Retries
@@ -275,7 +279,7 @@ func resetFileForWriting(file *os.File) error {
 	return err
 }
 
-func tryGetObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) error {
+func tryGetObject(s3Client S3Getter, bucket *string, key *string, file *os.File) error {
 	out, err := s3Client.GetObject(&s3.GetObjectInput{
 		Bucket: bucket,
 		Key:    key,

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -225,8 +225,8 @@ func process(s3Client *s3.S3, src S3Path, basePath string, filePath string, sem 
 	}
 	defer out.Body.Close()
 
-	target := basePath + "/" + strings.TrimPrefix(filePath, src.Dirname()+"/")
-	err = store(out, target)
+	destination := basePath + "/" + strings.TrimPrefix(filePath, src.Dirname()+"/")
+	err = store(out, destination)
 	if err != nil {
 		exitErrorf("%v", err)
 	}

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -219,12 +219,6 @@ func process(s3Client *s3.S3, src S3Path, basePath string, filePath string, sem 
 		return
 	}
 
-	out, err := getObject(s3Client, aws.String(src.bucket), &filePath)
-	if err != nil {
-		exitErrorf("%v", err)
-	}
-	defer out.Body.Close()
-
 	destination := basePath + "/" + strings.TrimPrefix(filePath, src.Dirname()+"/")
 	file, err := createFile(destination)
 	if err != nil {
@@ -232,6 +226,12 @@ func process(s3Client *s3.S3, src S3Path, basePath string, filePath string, sem 
 	}
 
 	defer file.Close()
+	
+	out, err := getObject(s3Client, aws.String(src.bucket), &filePath)
+	if err != nil {
+		exitErrorf("%v", err)
+	}
+	defer out.Body.Close()
 
 	err = storeS3ObjectToFile(out, file)
 	if err != nil {

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -308,7 +308,7 @@ func createFile(destination string) (*os.File, error) {
 
 	file, err := os.Create(destination)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating destination %s", file.Name())
+		return nil, errors.Wrapf(err, "creating destination %s", destination)
 	}
 	return file, nil
 }

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -261,8 +261,8 @@ func copyS3ObjectToFile(s3Client S3Getter, src S3Path, filePath string, file *os
 		resetErr := resetFileForWriting(file)
 		if resetErr != nil {
 			fmt.Printf("Unable to download object from S3 (%s) and unable reset temp file to try again (%s)",
-								err,
-								resetErr)
+				err,
+				resetErr)
 			return errors.Wrapf(resetErr, "unable to reset temp file %s", file.Name())
 		}
 		retries--

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -243,7 +243,7 @@ func process(s3Client *s3.S3, src S3Path, basePath string, filePath string, sem 
 }
 
 func copyS3ObjectToFile(s3Client *s3.S3, src S3Path, filePath string, file *os.File) error {
-	out, err := getObject(s3Client, aws.String(src.bucket), &filePath)
+	out, err := getObject(s3Client, aws.String(src.bucket), &filePath, file)
 	if err != nil {
 		return err
 	}
@@ -253,7 +253,7 @@ func copyS3ObjectToFile(s3Client *s3.S3, src S3Path, filePath string, file *os.F
 	return storeS3ObjectToFile(out, file)
 }
 
-func getObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutput, error) {
+func getObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) (*s3.GetObjectOutput, error) {
 	var (
 		err error
 		out *s3.GetObjectOutput
@@ -261,7 +261,7 @@ func getObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutpu
 
 	retries := s3Retries
 	for retries > 0 {
-		out, err = tryGetObject(s3Client, bucket, key)
+		out, err = tryGetObject(s3Client, bucket, key, file)
 		if err == nil {
 			return out, nil
 		}
@@ -275,11 +275,13 @@ func getObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutpu
 	return nil, err
 }
 
-func tryGetObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutput, error) {
-	return s3Client.GetObject(&s3.GetObjectInput{
+func tryGetObject(s3Client *s3.S3, bucket *string, key *string, file *os.File) (*s3.GetObjectOutput, error) {
+	out, err := s3Client.GetObject(&s3.GetObjectInput{
 		Bucket: bucket,
 		Key:    key,
 	})
+
+	return out, err
 }
 
 func storeS3ObjectToFile(obj *s3.GetObjectOutput, file *os.File) error {

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -40,10 +40,11 @@ var (
 	getSubdir     string
 )
 
+var s3RetriesSleep = 10 * time.Second
+
 const (
 	s3ParallelGets = 100
 	s3Retries      = 10
-	s3RetriesSleep = 10 * time.Second
 )
 
 var getCmd = &cobra.Command{

--- a/cli/data/get.go
+++ b/cli/data/get.go
@@ -261,10 +261,7 @@ func getObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutpu
 
 	retries := s3Retries
 	for retries > 0 {
-		out, err = s3Client.GetObject(&s3.GetObjectInput{
-			Bucket: bucket,
-			Key:    key,
-		})
+		out, err = tryGetObject(s3Client, bucket, key)
 		if err == nil {
 			return out, nil
 		}
@@ -276,6 +273,13 @@ func getObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutpu
 		}
 	}
 	return nil, err
+}
+
+func tryGetObject(s3Client *s3.S3, bucket *string, key *string) (*s3.GetObjectOutput, error) {
+	return s3Client.GetObject(&s3.GetObjectInput{
+		Bucket: bucket,
+		Key:    key,
+	})
 }
 
 func storeS3ObjectToFile(obj *s3.GetObjectOutput, file *os.File) error {

--- a/cli/data/get_test.go
+++ b/cli/data/get_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"io/ioutil"
+	"strings"
 	"testing"
 )
 
@@ -64,8 +65,19 @@ func TestFilterObjectsUsingNonExistentKeys(t *testing.T) {
 	}
 }
 
+type S3GetterFromString struct {
+	s string
+}
+
+func (s3FromString S3GetterFromString) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	out := s3.GetObjectOutput {
+		Body: ioutil.NopCloser(strings.NewReader(s3FromString.s)),
+	}
+	return &out, nil
+}
+
 func Test_copyS3ObjectToFile_worksFirstTime(t *testing.T) {
-	var s3Client S3Getter = nil
+	var s3Client S3Getter = S3GetterFromString{"foobar"}
 	s3Path := S3Path{bucket: "bucket", path: "path/"}
 	filePath := "foo/bar"
 	tempFile, _ := ioutil.TempFile("", "testDownload")

--- a/cli/data/get_test.go
+++ b/cli/data/get_test.go
@@ -52,7 +52,7 @@ func TestFilterObjectsWithNoKeys(t *testing.T) {
 
 func TestFilterObjectsUsingNonExistentKeys(t *testing.T) {
 	var (
-		key   = "path/f1.csv"
+		key    = "path/f1.csv"
 		obj    = &s3.Object{Key: &key}
 		s3Path = S3Path{bucket: "bucket", path: "path/"}
 		keys   = []string{"f2.csv", "f3.csv"}
@@ -71,8 +71,9 @@ func TestFilterObjectsUsingNonExistentKeys(t *testing.T) {
 type s3GetterFromString struct {
 	s string
 }
+
 func (s3FromString s3GetterFromString) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
-	out := s3.GetObjectOutput {
+	out := s3.GetObjectOutput{
 		Body: ioutil.NopCloser(strings.NewReader(s3FromString.s)),
 	}
 	return &out, nil
@@ -102,6 +103,7 @@ func Test_copyS3ObjectToFile_worksFirstTime(t *testing.T) {
 
 type s3FailingGetter struct {
 }
+
 func (s3FailingGetter *s3FailingGetter) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	return nil, errors.New("can't connect to S3")
 }
@@ -122,8 +124,9 @@ func Test_copyS3ObjectToFile_failsToGetObjectFromS3(t *testing.T) {
 
 type s3FailingReader struct {
 }
+
 func (s3FailingReader *s3FailingReader) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
-	out := s3.GetObjectOutput {
+	out := s3.GetObjectOutput{
 		Body: ioutil.NopCloser(&failingReader{}),
 	}
 	return &out, nil
@@ -131,6 +134,7 @@ func (s3FailingReader *s3FailingReader) GetObject(input *s3.GetObjectInput) (*s3
 
 type failingReader struct {
 }
+
 func (r *failingReader) Read(p []byte) (int, error) {
 	return 0, errors.New("failing reader")
 }
@@ -152,8 +156,9 @@ func Test_copyS3ObjectToFile_failsToReadFromS3(t *testing.T) {
 type s3GetterFailOnClose struct {
 	s string
 }
+
 func (s3GetterFailOnClose *s3GetterFailOnClose) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
-	out := s3.GetObjectOutput {
+	out := s3.GetObjectOutput{
 		Body: failOnClose{strings.NewReader(s3GetterFailOnClose.s)},
 	}
 	return &out, nil
@@ -162,6 +167,7 @@ func (s3GetterFailOnClose *s3GetterFailOnClose) GetObject(input *s3.GetObjectInp
 type failOnClose struct {
 	io.Reader
 }
+
 func (failOnClose) Close() error {
 	return errors.New("failed while closing")
 }
@@ -182,17 +188,18 @@ func Test_copyS3ObjectToFile_failsWhenClosingStream(t *testing.T) {
 
 type s3GetterFailsFirstFewAttempts struct {
 	unsuccessfulReads int
-	s string
+	s                 string
 }
+
 func (s3GetterFailsFirstFewAttempts *s3GetterFailsFirstFewAttempts) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	var out s3.GetObjectOutput
 	if s3GetterFailsFirstFewAttempts.unsuccessfulReads == 0 {
-		out = s3.GetObjectOutput {
+		out = s3.GetObjectOutput{
 			Body: ioutil.NopCloser(strings.NewReader(s3GetterFailsFirstFewAttempts.s)),
 		}
 	} else {
 		s3GetterFailsFirstFewAttempts.unsuccessfulReads--
-		out = s3.GetObjectOutput {
+		out = s3.GetObjectOutput{
 			Body: ioutil.NopCloser(&failingReader{}),
 		}
 	}

--- a/cli/data/get_test.go
+++ b/cli/data/get_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"github.com/aws/aws-sdk-go/service/s3"
+	"io/ioutil"
 	"testing"
 )
 
@@ -61,4 +62,13 @@ func TestFilterObjectsUsingNonExistentKeys(t *testing.T) {
 	if err == nil {
 		t.Error("It should return an error")
 	}
+}
+
+func Test_copyS3ObjectToFile_worksFirstTime(t *testing.T) {
+	var s3Client S3Getter = nil
+	s3Path := S3Path{bucket: "bucket", path: "path/"}
+	filePath := "foo/bar"
+	tempFile, _ := ioutil.TempFile("", "testDownload")
+
+	copyS3ObjectToFile(s3Client, s3Path, filePath, tempFile)
 }

--- a/cli/data/get_test.go
+++ b/cli/data/get_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFilterObjects(t *testing.T) {
@@ -107,6 +108,7 @@ func (s3FailingGetter s3FailingGetter) GetObject(input *s3.GetObjectInput) (*s3.
 
 func Test_copyS3ObjectToFile_failsToGetObjectFromS3(t *testing.T) {
 	var s3Client S3Getter = s3FailingGetter{}
+	s3RetriesSleep = 1 * time.Second
 
 	s3Path := S3Path{bucket: "bucket", path: "path/"}
 	filePath := "foo/bar"
@@ -136,6 +138,7 @@ func (s3FailingReader s3FailingReader) GetObject(input *s3.GetObjectInput) (*s3.
 
 func Test_copyS3ObjectToFile_failsToReadFromS3(t *testing.T) {
 	var s3Client S3Getter = s3FailingReader{}
+	s3RetriesSleep = 1 * time.Second
 
 	s3Path := S3Path{bucket: "bucket", path: "path/"}
 	filePath := "foo/bar"
@@ -170,6 +173,7 @@ func (s3GetterFailOnClose s3GetterFailOnClose) GetObject(input *s3.GetObjectInpu
 
 func Test_copyS3ObjectToFile_failsWhenClosingStream(t *testing.T) {
 	var s3Client S3Getter = s3FailingReader{}
+	s3RetriesSleep = 1 * time.Second
 
 	s3Path := S3Path{bucket: "bucket", path: "path/"}
 	filePath := "foo/bar"
@@ -204,6 +208,7 @@ func (s3GetterFailsFirstFewAttempts *s3GetterFailsFirstFewAttempts) GetObject(in
 
 func Test_copyS3ObjectToFile_failsFirstFewReadAttemptsButRetries(t *testing.T) {
 	var s3Client S3Getter = &s3GetterFailsFirstFewAttempts{5, "foobar"}
+	s3RetriesSleep = 1 * time.Second
 
 	s3Path := S3Path{bucket: "bucket", path: "path/"}
 	filePath := "foo/bar"

--- a/cli/data/get_test.go
+++ b/cli/data/get_test.go
@@ -78,9 +78,22 @@ func (s3FromString S3GetterFromString) GetObject(input *s3.GetObjectInput) (*s3.
 
 func Test_copyS3ObjectToFile_worksFirstTime(t *testing.T) {
 	var s3Client S3Getter = S3GetterFromString{"foobar"}
+
 	s3Path := S3Path{bucket: "bucket", path: "path/"}
 	filePath := "foo/bar"
 	tempFile, _ := ioutil.TempFile("", "testDownload")
 
-	copyS3ObjectToFile(s3Client, s3Path, filePath, tempFile)
+	err := copyS3ObjectToFile(s3Client, s3Path, filePath, tempFile)
+	if err != nil {
+		t.Errorf("Should have downloaded file successfully but didn't: %v", err)
+	}
+
+	bytes, err := ioutil.ReadFile(tempFile.Name())
+	if err != nil {
+		t.Errorf("Should be able to read from 'downloaded' file but couldn't %v", err)
+	}
+
+	if string(bytes) != "foobar" {
+		t.Errorf("File contents were incorrect.  Expected '%s' but got '%s'", "foobar", string(bytes))
+	}
 }


### PR DESCRIPTION
Ticket: https://deliveroo.atlassian.net/browse/NSA-500

**What**
Change the retry logic in `paddle data get` so it covers additional transient failure cases that are worth retrying.

**Why**
NSA have seen some failures in our pipelines because copying the data from S3 into a local file failed for a transient reason.  Before this PR the cli had retries around asking s3 for the object (`s3.GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)`) but not around actually pulling the bytes across the network and copying them into the file locally (`io.Copy(foo, s3.GetObjectOutput.Body)`).

This led to failures in our pipelines because we failed when copying the object into a local file which weren't retried.
```
2020/01/07 12:03:13 [rider-planning-duke-backbone-master/paddle]: /data/input/slots_surge_and_order_volume.csv -> 1309073807 bytes
2020/01/07 12:08:22 [rider-planning-duke-backbone-master/paddle]: copying file /data/input/driver_hourly_schedule_in_app.csv: read tcp 100.117.27.117:48523->52.218.24.160:443: read: connection reset by peer
2020/01/07 12:08:25 [paddle] Container removed: paddle
```

This PR moves the retries to be around both connecting to s3 and copying the data locally.

**How**
Firstly I refactored how the class fetches files and the special case of fetching the `HEAD` file.  Previously files were fetched as you would expect but the `HEAD` file got the contents and copied them directly into a `string`.  The retry was in getting the contents so if I moved the retry further up the stack for fetching files the `readHEAD` method would no longer benefit from the retries.  So I changed `readHEAD` to copy the object into a temporary file and then read the contents.  This unified the code paths and made it easier to refactor.

This then gives a method called `copyS3ObjectToFile` which is used by both code paths and is easier to test in isolation.  I moved the retry logic into this method so both connecting to s3 and copying the bytes into the file are now inside the retry loop.  We have to reset the file if we fail to copy because some bytes may already be written to the file.

**Testing**
Previously there were no tests for reading files from S3.  I've now added tests for the happy case (read successfully first time), failures at each step and success after a number of retries.  I made the time between retries configurable so these tests don't take too long.

The tests work by pulling out a structural type `S3Getter` which encapsulates the `GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)` method we need from the full aws client.

I have not yet tested this on a pipeline but will do this once I've got feedback on this PR.

**Where to start**
Only covers 2 classes.  I'm not familiar with Go so the individual commits are very small, not sure if it is useful to follow them.

**Open Questions**
This is my first time writing Go so I may have made some dumb mistakes, missed some obvious library code that could have helped or written code in a style that isn't idiomatic.
This class also lists the keys with a given prefix - should I add retries around this operation too?  We haven't seen it fail yet but it could.

**Urgency**
Not urgent